### PR TITLE
Use opaque{} instead of c_void

### DIFF
--- a/example/simple.zig
+++ b/example/simple.zig
@@ -56,7 +56,7 @@ pub fn main() !void {
     var instance = try wasmtime.Instance.init(store, module, func);
     std.debug.warn("Instance initialized...\n", .{});
 
-    if (try instance.getFirstFuncExport()) |f| {
+    if (instance.getExportFunc("run")) |f| {
         std.debug.warn("Calling export...\n", .{});
         try f.call();
     } else {

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,8 +1,8 @@
 pub const WasmError = opaque {
     /// Gets the error message
-    pub fn getMessage(self: *WasmError) *ByteVec {
-        const bytes: *ByteVec = undefined;
-        wasmtime_error_message(self, bytes);
+    pub fn getMessage(self: *WasmError) ByteVec {
+        var bytes: ByteVec = undefined;
+        wasmtime_error_message(self, &bytes);
         return bytes;
     }
 
@@ -41,9 +41,9 @@ pub const ExportType = opaque {
 
 pub const ExportTypeVec = extern struct {
     size: usize,
-    data: [*]*ExportType,
+    data: [*]?*ExportType,
 
-    pub fn toSlice(self: *ExportTypeVec) []const *ExportType {
+    pub fn toSlice(self: *const ExportTypeVec) []const ?*ExportType {
         return self.data[0..self.size];
     }
 
@@ -59,10 +59,10 @@ pub const InstanceType = opaque {
         self.wasm_instancetype_delete();
     }
 
-    pub fn exports(self: *InstanceType) *ExportTypeVec {
+    pub fn exports(self: *InstanceType) ExportTypeVec {
         var export_vec: ExportTypeVec = undefined;
         self.wasm_instancetype_exports(&export_vec);
-        return &export_vec;
+        return export_vec;
     }
 
     extern fn wasm_instancetype_delete(*InstanceType) void;
@@ -99,7 +99,7 @@ pub const ByteVec = extern struct {
 
 pub const ExternVec = extern struct {
     size: usize,
-    data: [*]*Extern,
+    data: [*]?*Extern,
 
     pub fn empty() ExternVec {
         return .{ .size = 0, .data = undefined };

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,17 +1,68 @@
+pub const WasmError = opaque {
+    /// Gets the error message
+    pub fn getMessage(self: *WasmError) ByteVec {
+        var bytes: ByteVec = undefined;
+        wasmtime_error_message(self, &bytes);
+        return bytes;
+    }
+
+    /// Frees the error resources
+    pub fn deinit(self: *WasmError) void {
+        wasmtime_error_delete(self);
+    }
+
+    extern fn wasmtime_error_delete(*WasmError) void;
+    extern fn wasmtime_error_message(*WasmError, *ByteVec) void;
+};
+
+pub const Trap = opaque {
+    pub fn deinit(self: *Trap) void {
+        wasm_trap_delete(self);
+    }
+
+    extern fn wasm_trap_delete(*Trap) void;
+};
+
+pub const Extern = opaque {
+    /// Returns the `Extern` as a function
+    pub fn asFunc(self: *Extern) ?*c_void {
+        return wasm_extern_as_func(self);
+    }
+};
+
 pub const Callback = fn (?*const wasm_val_t, ?*wasm_val_t) callconv(.C) ?*c_void;
 
 // Bits
-pub const wasm_byte_vec_t = extern struct {
+pub const ByteVec = extern struct {
     size: usize,
     data: [*]u8,
+
+    /// Initializes a new wasm byte vector
+    pub fn initWithCapacity(size: usize) ByteVec {
+        var bytes: ByteVec = undefined;
+        wasm_byte_vec_new_uninitialized(&bytes, size);
+        return bytes;
+    }
+
+    /// Returns a slice to the byte vector
+    pub fn toSlice(self: ByteVec) []const u8 {
+        return self.data[0..self.size];
+    }
+
+    /// Frees the memory allocated by initWithCapacity
+    pub fn deinit(self: *ByteVec) void {
+        wasm_byte_vec_delete(self);
+    }
 };
 
-pub extern fn wasm_byte_vec_new_uninitialized(ptr: *wasm_byte_vec_t, size: usize) void;
-pub extern fn wasm_byte_vec_delete(ptr: *wasm_byte_vec_t) void;
+// pub const ByteVec = ByteVec;
+
+pub extern fn wasm_byte_vec_new_uninitialized(ptr: *ByteVec, size: usize) void;
+extern fn wasm_byte_vec_delete(ptr: *ByteVec) void;
 
 pub const wasm_extern_vec_t = extern struct {
     size: usize,
-    data: [*]?*c_void,
+    data: [*]?*Extern,
 };
 
 pub extern fn wasm_extern_vec_new_empty(ptr: *wasm_extern_vec_t) void;
@@ -40,27 +91,24 @@ pub const wasm_val_t = extern struct {
 pub const wasm_valtype_vec_t = extern struct {
     size: usize,
     data: [*]?*c_void,
+
+    pub fn empty() wasm_valtype_vec_t {
+        var ptr: wasm_valtype_vec_t = undefined;
+        wasm_valtype_vec_new_empty(&ptr);
+        return ptr;
+    }
 };
+
+pub const ValtypeVec = wasm_valtype_vec_t;
 
 pub extern fn wasm_valtype_vec_new_empty(ptr: *wasm_valtype_vec_t) void;
 
 // Engine
-pub extern fn wasm_engine_new() ?*c_void;
 pub extern fn wasm_engine_delete(engine: *c_void) void;
 
 // Store
 pub extern fn wasm_store_new(engine: *c_void) ?*c_void;
 pub extern fn wasm_store_delete(store: *c_void) void;
-
-// Module
-pub extern fn wasmtime_module_new(engine: *c_void, wasm: *wasm_byte_vec_t, module: *?*c_void) ?*c_void;
-pub extern fn wasmtime_module_validate(store: *c_void, wasm: *wasm_byte_vec_t) ?*c_void;
-pub extern fn wasm_module_delete(module: *c_void) void;
-
-// Instance
-pub extern fn wasmtime_instance_new(store: *c_void, module: *const c_void, imports: [*]const ?*const c_void, size: usize, instance: *?*c_void, trap: *?*c_void) ?*c_void;
-pub extern fn wasm_instance_delete(instance: *c_void) void;
-pub extern fn wasm_instance_exports(instance: *c_void, externs: *wasm_extern_vec_t) void;
 
 // Func
 pub extern fn wasm_functype_new(args: *wasm_valtype_vec_t, results: *wasm_valtype_vec_t) ?*c_void;
@@ -72,12 +120,10 @@ pub extern fn wasm_func_copy(func: *c_void) ?*c_void;
 pub extern fn wasm_func_as_extern(func: *c_void) ?*c_void;
 pub extern fn wasm_extern_as_func(external: *c_void) ?*c_void;
 
-pub extern fn wasmtime_func_call(func: *c_void, args: ?*const wasm_val_t, args_size: usize, results: ?*wasm_val_t, results_size: usize, trap: *?*c_void) ?*c_void;
+pub extern fn wasmtime_func_call(func: *c_void, args: ?*const wasm_val_t, args_size: usize, results: ?*wasm_val_t, results_size: usize, trap: *?*c_void) ?*WasmError;
 
 // Error handling
-pub extern fn wasmtime_error_delete(err: *c_void) void;
-pub extern fn wasmtime_error_message(err: *c_void, msg: *wasm_byte_vec_t) void;
 pub extern fn wasm_trap_delete(trap: *c_void) void;
 
 // Helpers
-pub extern fn wasmtime_wat2wasm(wat: *wasm_byte_vec_t, wasm: *wasm_byte_vec_t) ?*c_void;
+pub extern fn wasmtime_wat2wasm(wat: *ByteVec, wasm: *ByteVec) ?*WasmError;


### PR DESCRIPTION
Allows us to make use of Zig's type system to ensure passing pointers around happens safely.
Increases the readability of the bindings itself also.