### PR TITLE
Add support for wasm function parameters and result type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
     - name: zig build test
       run: |
         zig build test -Dlibrary-search-path="."
-    - name: zig build example-simple
+    - name: zig build run -Dexample=simple
       run: |
-        zig build example-simple -Dlibrary-search-path="."
+        zig build run -Dexample=simple -Dlibrary-search-path="."
+    - name: zig build run -Dexample=gcd
+      run: |
+        zig build run -Dexample=gcd -Dlibrary-search-path="."
 

--- a/example/gcd.wat
+++ b/example/gcd.wat
@@ -1,0 +1,27 @@
+(module
+  (func $gcd (param i32 i32) (result i32)
+    (local i32)
+    block  ;; label = @1
+      block  ;; label = @2
+        local.get 0
+        br_if 0 (;@2;)
+        local.get 1
+        local.set 2
+        br 1 (;@1;)
+      end
+      loop  ;; label = @2
+        local.get 1
+        local.get 0
+        local.tee 2
+        i32.rem_u
+        local.set 0
+        local.get 2
+        local.set 1
+        local.get 0
+        br_if 0 (;@2;)
+      end
+    end
+    local.get 2
+  )
+  (export "gcd" (func $gcd))
+)

--- a/example/gcd.zig
+++ b/example/gcd.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
     defer module.deinit();
     std.debug.print("Wasm module compiled...\n", .{});
 
-    var instance = try wasmtime.Instance.init(store, module, &.{});
+    var instance = try wasmtime.Instance.init(store, module, &[_]*wasmtime.Func{});
     std.debug.print("Instance initialized...\n", .{});
 
     if (instance.getExportFunc("gcd")) |f| {

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -53,7 +53,7 @@ pub fn main() !void {
     var func = try wasmtime.Func.init(store, hello);
     std.debug.print("Func callback prepared...\n", .{});
 
-    var instance = try wasmtime.Instance.init(store, module, &.{func});
+    var instance = try wasmtime.Instance.init(store, module, &[_]*wasmtime.Func{func});
     std.debug.print("Instance initialized...\n", .{});
 
     if (instance.getExportFunc("run")) |f| {

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -40,26 +40,26 @@ pub fn main() !void {
 
     var engine = try wasmtime.Engine.init();
     defer engine.deinit();
-    std.debug.warn("Engine initialized...\n", .{});
+    std.debug.print("Engine initialized...\n", .{});
 
     var store = try wasmtime.Store.init(engine);
     defer store.deinit();
-    std.debug.warn("Store initialized...\n", .{});
+    std.debug.print("Store initialized...\n", .{});
 
     var module = try wasmtime.Module.initFromWat(engine, wasm);
     defer module.deinit();
-    std.debug.warn("Wasm module compiled...\n", .{});
+    std.debug.print("Wasm module compiled...\n", .{});
 
     var func = try wasmtime.Func.init(store, hello);
-    std.debug.warn("Func callback prepared...\n", .{});
+    std.debug.print("Func callback prepared...\n", .{});
 
     var instance = try wasmtime.Instance.init(store, module, &.{func});
-    std.debug.warn("Instance initialized...\n", .{});
+    std.debug.print("Instance initialized...\n", .{});
 
     if (instance.getExportFunc("run")) |f| {
-        std.debug.warn("Calling export...\n", .{});
+        std.debug.print("Calling export...\n", .{});
         try f.call(void, .{});
     } else {
-        std.debug.warn("Export not found...\n", .{});
+        std.debug.print("Export not found...\n", .{});
     }
 }

--- a/src/c.zig
+++ b/src/c.zig
@@ -162,7 +162,7 @@ pub const Valtype = opaque {
 
 pub const ValtypeVec = extern struct {
     size: usize,
-    data: [*]?*Value,
+    data: [*]?*Valtype,
 
     pub fn empty() ValtypeVec {
         return .{ .size = 0, .data = undefined };


### PR DESCRIPTION
- This adds the gcd example from the wasmtime examples.
- Provides a dynamic build.zig file to allow users to run any example using `-Dexample=<example_name>`
- Adds support for providing arguments to wasm functions.
- Adds support for returning the return value of a wasm function.