### PR TITLE
Implement interrupt example

### DIFF
--- a/example/interrupt.wat
+++ b/example/interrupt.wat
@@ -1,0 +1,6 @@
+(module
+  (func (export "run")
+    (loop
+      br 0)
+  )
+)


### PR DESCRIPTION
- Interrupt handling
- Engine with config
- Make previous examples easier by using `readtoEndAlloc()`
