### PR TITLE
Use latest zig tarball on macOS

### DIFF
--- a/ci/macos_ci
+++ b/ci/macos_ci
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-ZIG="zig-macos-x86_64-0.8.0-dev.2667+44de88498"
+ZIG="zig-macos-x86_64-0.8.0-dev.2670+d8d92dafe"
 WASMTIME_VERSION="v0.24.0"
 WASMTIME="wasmtime-$WASMTIME_VERSION-x86_64-macos-c-api"
 GYRO_VERSION="0.2.3"

--- a/deps.zig
+++ b/deps.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 pub const pkgs = struct {
     pub const wasm = std.build.Pkg{
         .name = "wasm",
-        .path = ".gyro/wasm-zig-kubkon-a8f98d100ae0ede37f42d5c084d1401805e1e843/pkg/src/main.zig",
+        .path = ".gyro/wasm-zig-zigwasm-3041a2dce58a41b49e9e6623bb07154e17e4911a/pkg/src/main.zig",
     };
 
     pub fn addAllTo(artifact: *std.build.LibExeObjStep) void {
@@ -16,5 +16,5 @@ pub const pkgs = struct {
 };
 
 pub const base_dirs = struct {
-    pub const wasm = ".gyro/wasm-zig-kubkon-a8f98d100ae0ede37f42d5c084d1401805e1e843/pkg";
+    pub const wasm = ".gyro/wasm-zig-zigwasm-3041a2dce58a41b49e9e6623bb07154e17e4911a/pkg";
 };

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -4,7 +4,7 @@ pkgs:
     root: src/main.zig
     description: Zig embedding of Wasmtime
     license: Apache-2.0
-    source_url: "https://github.com/kubkon/wasmtime-zig"
+    source_url: "https://github.com/zigwasm/wasmtime-zig"
     tags:
       wasmtime
       wasm
@@ -13,6 +13,6 @@ deps:
   wasm:
     src:
       github:
-        user: kubkon
+        user: zigwasm
         repo: wasm-zig
         ref: main


### PR DESCRIPTION
Includes needed changes to `zld` which should fix our macOS build.